### PR TITLE
Fix datasource path handling

### DIFF
--- a/shinken/modules/snmp_poller.py
+++ b/shinken/modules/snmp_poller.py
@@ -1169,7 +1169,7 @@ class Snmp_poller(BaseModule):
             # if directory
             elif os.path.isdir(self.datasource_file):
                 files = glob.glob(os.path.join(self.datasource_file,
-                                               '/Default*.ini')
+                                               'Default*.ini')
                                  )
                 for f in files:
                     if self.datasource is None:


### PR DESCRIPTION
According to python doc, os.path.join() will throw away all arguments before an argument looking like an absolute path. In my case join("/etc/shinken/SNMP","/Default_.ini") resulted in "/Default_.ini" instead of "/etc/shinken/SNMP/Default*.ini".

This small patch fixes this bug.

Best regards,

N-Mi.
