### PR TITLE
Update snmp_poller.py

### DIFF
--- a/shinken/modules/snmp_poller.py
+++ b/shinken/modules/snmp_poller.py
@@ -1168,8 +1168,9 @@ class Snmp_poller(BaseModule):
 
             # if directory
             elif os.path.isdir(self.datasource_file):
+                if not self.datasource_file.endswith("/") : self.datasource_file.join(self.datasource_file, "/") 
                 files = glob.glob(os.path.join(self.datasource_file,
-                                               '/Default*.ini')
+                                               'Default*.ini')
                                  )
                 for f in files:
                     if self.datasource is None:
@@ -1179,7 +1180,7 @@ class Snmp_poller(BaseModule):
                         ctemp = ConfigObj(f, interpolation='template')
                         self.datasource.merge(ctemp)
             else:
-                raise IOError, "File or folder not found"
+                raise IOError, "File or folder not found: %s" % self.datasource_file
             # Store config in memcache
             self.memcached.set('datasource', self.datasource, time=604800)
         # TODO


### PR DESCRIPTION
os.path.join does not permit leading slash in N+1 arguments or else it will use that as the new starting path. Remove leading slash and add a verification to the datasource_file. Validation could occur at import to make it easier.
